### PR TITLE
Fix failing travis build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+_site/
+.sass-cache/
+.jekyll-cache/
+.jekyll-metadata
+vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,7 @@ install:
   - gem update --system
   - bundle install
 
-script:
-  - git pull origin gh-pages
-  - bundle exec rake site:deploy --quiet #--trace
+script: bundle exec rake site:deploy --quiet #--trace
 
 # Generate your secure token with the travis gem:
 # get Github token from your Travis CI profile page

--- a/_config.yml
+++ b/_config.yml
@@ -76,7 +76,7 @@ username: webclub-nitk
 repo: blog
 branch: master
 relative_source: #../jasper2/
-destination: _site/
+destination: ../site/
 production_url:  https://webclub.nitk.ac.in/blog/
 source_url:  https://github.com/webclub-nitk/blog/
 


### PR DESCRIPTION
Jekyll-travis, the source for travis configuration deploys as follows:
- Clone repo to an external folder `destination` if not present already.
- Checkout `destination-branch` in the external folder.
- Generate the site.
- Stage changes, commit and push to `destination-branch` from the
  external folder.

The builds were failing because CONFIG['destination'] was misconfigured
to `_site` i.e an existing internal folder which prevents the clone.
Since Travis fetches the build branch only, checking out to `gh-pages`
throws the error message.

Fixes the error, adds gitignore.

## Invalid secure key

![Screenshot_2020-03-04 WebClub-NITK blog](https://user-images.githubusercontent.com/31231064/75876292-70657480-5e3b-11ea-838e-8abe3f603065.png)

@mishal23 - The secure key has an invalid format. Please fix it by either pushing to this branch or through another branch.